### PR TITLE
Correct formatting of code blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ player.Dispose();
 
 ### The library structure
 
-<del>The current version of managed-midi is designed to be packaged as a NuGet library using NuGetizer 3000: https://github.com/NuGet/NuGet.Build.Packaging<del>I cannot build both CoreMidi (XamMac) and UWP at the same time, so it will be packaged manually.
+<del>The current version of managed-midi is designed to be packaged as a NuGet library using NuGetizer 3000: https://github.com/NuGet/NuGet.Build.Packaging</del>I cannot build both CoreMidi (XamMac) and UWP at the same time, so it will be packaged manually.
 
 There is no reference assembly; the PCL package is part of the package, which contains *no* raw MIDI API access implementation. It can still be used to implement platform-specific API on top of it.
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ player.Dispose();
 
 ### The library structure
 
-~~The current version of managed-midi is designed to be packaged as a NuGet library using NuGetizer 3000: https://github.com/NuGet/NuGet.Build.Packaging~~I cannot build both CoreMidi (XamMac) and UWP at the same time, so it will be packaged manually.
+<del>The current version of managed-midi is designed to be packaged as a NuGet library using NuGetizer 3000: https://github.com/NuGet/NuGet.Build.Packaging<del>I cannot build both CoreMidi (XamMac) and UWP at the same time, so it will be packaged manually.
 
 There is no reference assembly; the PCL package is part of the package, which contains *no* raw MIDI API access implementation. It can still be used to implement platform-specific API on top of it.
 

--- a/README.md
+++ b/README.md
@@ -101,42 +101,44 @@ When trying them below, C# shell is useful: `csharp -r Commons.Music.Midi.Deskto
 
 Make sure that you have active and audible (i.e. non-thru) MIDI output device.
 
-  using Commons.Music.Midi;
+```csharp
+using Commons.Music.Midi;
 
-  var access = MidiAccessManager.Default;
-  var output = access.OpenOutputAsync(access.Outputs.Last().Id).Result;
-  output.SendAsync(new byte [] {0xC0, 0x0}, 0, 2, 0); // Piano
-  output.SendAsync(new byte [] {0x90, 0x40, 0x70}, 0, 3, 0);
-  output.SendAsync(new byte [] {0x80, 0x40, 0x70}, 0, 3, 0);
-  output.SendAsync(new byte [] {0xC0, 0x30}, 3, 2, 0); // Strings Ensemble
-  output.SendAsync(new byte [] {0x90, 0x40, 0x70}, 0, 3, 0);
-  output.SendAsync(new byte [] {0x80, 0x40, 0x70}, 0, 3, 0);
-  output.CloseAsync();
+var access = MidiAccessManager.Default;
+var output = access.OpenOutputAsync(access.Outputs.Last().Id).Result;
+output.SendAsync(new byte [] {0xC0, 0x0}, 0, 2, 0); // Piano
+output.SendAsync(new byte [] {0x90, 0x40, 0x70}, 0, 3, 0);
+output.SendAsync(new byte [] {0x80, 0x40, 0x70}, 0, 3, 0);
+output.SendAsync(new byte [] {0xC0, 0x30}, 3, 2, 0); // Strings Ensemble
+output.SendAsync(new byte [] {0x90, 0x40, 0x70}, 0, 3, 0);
+output.SendAsync(new byte [] {0x80, 0x40, 0x70}, 0, 3, 0);
+output.CloseAsync();
+```
 
 ### Play MIDI song file (SMF), detecting specific events
 
-  using Commons.Music.Midi;
+```csharp
+using Commons.Music.Midi;
 
-  var access = MidiAccessManager.Default;
-  var output = access.OpenOutputAsync(access.Outputs.Last().Id).Result;
-  var music = MidiMusic.Read(System.IO.File.OpenRead("mysong.mid"));
-  var player = new MidiPlayer(music, output);
-  player.EventReceived += (MidiEvent e) => {
-    if (e.EventType == MidiEvent.Program)
-      Console.WriteLine ($"Program changed: Channel:{e.Channel} Instrument:{e.Msb}");
-    };
-  player.PlayAsync();
-  Console.WriteLine("Type [CR] to stop.");
-  Console.ReadLine();
-  player.Dispose();
-
-
+var access = MidiAccessManager.Default;
+var output = access.OpenOutputAsync(access.Outputs.Last().Id).Result;
+var music = MidiMusic.Read(System.IO.File.OpenRead("mysong.mid"));
+var player = new MidiPlayer(music, output);
+player.EventReceived += (MidiEvent e) => {
+  if (e.EventType == MidiEvent.Program)
+    Console.WriteLine ($"Program changed: Channel:{e.Channel} Instrument:{e.Msb}");
+  };
+player.PlayAsync();
+Console.WriteLine("Type [CR] to stop.");
+Console.ReadLine();
+player.Dispose();
+```
 
 ## HACKING
 
 ### The library structure
 
-<del>The current version of managed-midi is designed to be packaged as a NuGet library using NuGetizer 3000: https://github.com/NuGet/NuGet.Build.Packaging</del>I cannot build both CoreMidi (XamMac) and UWP at the same time, so it will be packaged manually.
+~~The current version of managed-midi is designed to be packaged as a NuGet library using NuGetizer 3000: https://github.com/NuGet/NuGet.Build.Packaging~~I cannot build both CoreMidi (XamMac) and UWP at the same time, so it will be packaged manually.
 
 There is no reference assembly; the PCL package is part of the package, which contains *no* raw MIDI API access implementation. It can still be used to implement platform-specific API on top of it.
 


### PR DESCRIPTION
Thanks for the addition of some examples I asked about in #5! I spotted that they weren't GitHub's markdown renderer wasn't picking the code blocks correctly on the web though, so this PR fixes that 😺 

Is there an (automatically generated?) API reference? Possibly hosted with something like _GitHub Pages_? It's certainly useful when using a library to have something to refer to.
