### PR TITLE
fix marshaling error with corert

### DIFF
--- a/Commons.Music.Midi.DesktopShared/winmm/WinmmMidiAccess.cs
+++ b/Commons.Music.Midi.DesktopShared/winmm/WinmmMidiAccess.cs
@@ -19,7 +19,7 @@ namespace Commons.Music.Midi.WinMM
 				for (uint i = 0; i < devs; i++)
 				{
 					MidiInCaps caps;
-					WinMMNatives.midiInGetDevCaps ((UIntPtr) i, out caps, (uint) Marshal.SizeOf (typeof (MidiInCaps)));
+					WinMMNatives.midiInGetDevCaps ((UIntPtr) i, out caps, (uint) Marshal.SizeOf<MidiInCaps>());
 					yield return new WinMMPortDetails (i, caps.Name, caps.DriverVersion);
 				}
 			}
@@ -30,7 +30,7 @@ namespace Commons.Music.Midi.WinMM
 				int devs = WinMMNatives.midiOutGetNumDevs ();
 				for (uint i = 0; i < devs; i++) {
 					MidiOutCaps caps;
-					var err = WinMMNatives.midiOutGetDevCaps ((UIntPtr) i, out caps, (uint) Marshal.SizeOf (typeof (MidiOutCaps)));
+					var err = WinMMNatives.midiOutGetDevCaps ((UIntPtr) i, out caps, (uint) Marshal.SizeOf<MidiOutCaps>());
                     if (err != 0)
                         throw new Win32Exception (err);
 					yield return new WinMMPortDetails (i, caps.Name, caps.DriverVersion);


### PR DESCRIPTION

When used in a corert compiled project I got the following error

Commons.Music.Midi.WinMM.MidiInCaps is missing structure marshalling data. To enable structure marshalling data, add a MarshalStructure directive to the application rd.xml file. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=393965

I found the fix here
https://github.com/dotnet/corert/issues/5374#issuecomment-455706335