### PR TITLE
Fix read dispatch delegate being GC'd

### DIFF
--- a/Commons.Music.Midi.CoreMidiShared/CoreMidiAccess.cs
+++ b/Commons.Music.Midi.CoreMidiShared/CoreMidiAccess.cs
@@ -92,7 +92,7 @@ namespace Commons.Music.Midi.CoreMidiApi
 		}
 	}
 
-	class CoreMidiPortDetails : IMidiPortDetails
+	class CoreMidiPortDetails : IMidiPortDetails, IDisposable
 	{
 		public CoreMidiPortDetails (MidiEndpoint src)
 		{
@@ -117,6 +117,11 @@ namespace Commons.Music.Midi.CoreMidiApi
 		public string Name { get; set; }
 
 		public string Version { get; set; }
+
+		public void Dispose()
+		{
+			Endpoint?.Dispose ();
+		}
 	}
 
 	class CoreMidiInput : IMidiInput
@@ -161,6 +166,7 @@ namespace Commons.Music.Midi.CoreMidiApi
 			port.Disconnect (details.Endpoint);
 			port.Dispose ();
 			client.Dispose ();
+			details.Dispose ();
 			return Task.CompletedTask;
 		}
 
@@ -192,6 +198,7 @@ namespace Commons.Music.Midi.CoreMidiApi
 			port.Disconnect (details.Endpoint);
 			port.Dispose ();
 			client.Dispose ();
+			details.Dispose ();
 			return Task.CompletedTask;
 		}
 


### PR DESCRIPTION
The fix applied in https://github.com/atsushieno/managed-midi/commit/d11d4e2f287c69884da22ce836548941165d59be is insufficient as the constructed delegate is not referenced (`ReadDispatcher` doesn't store a reference to it).

I've applied the same fix to `MidiEndpoint` which uses `ReadDispatcher`, and implemented a `Dispose()` method on it in a similar fashion.