### PR TITLE
Fix NotImplementedException being thrown on notify

### DIFF
--- a/Commons.Music.Midi.DesktopShared/coremidi/CoreMidiInterop.cs
+++ b/Commons.Music.Midi.DesktopShared/coremidi/CoreMidiInterop.cs
@@ -305,18 +305,13 @@ namespace CoreMidi {
 		{
 			IntPtr h;
 			name_string = Midi.ToCFStringRef (name);
-			int ret = CoreMidiInterop.MIDIClientCreate (name_string, OnNotify, IntPtr.Zero, out h);
+			int ret = CoreMidiInterop.MIDIClientCreate (name_string, null, IntPtr.Zero, out h);
 			if (ret != 0)
 				throw new MidiException ($"Failed to create MIDI client for {name}: error code {ret}");
 			Handle = h;
 		}
 
 		CFStringRef name_string;
-
-		void OnNotify (IntPtr message, IntPtr refCon)
-		{
-			throw new NotImplementedException ();
-		}
 
 		public MIDIClientRef Handle { get; private set; }
 


### PR DESCRIPTION
This was being received on disconnections.

https://developer.apple.com/documentation/coremidi/1495360-midiclientcreate documents that `null` is a supported value.