### PR TITLE
Use simpler constructor for MidiPacket on CoreMidi, as Xamarin CoreMi…

### DIFF
--- a/Commons.Music.Midi.CoreMidiShared/CoreMidiAccess.cs
+++ b/Commons.Music.Midi.CoreMidiShared/CoreMidiAccess.cs
@@ -212,12 +212,8 @@ namespace Commons.Music.Midi.CoreMidiApi
 		MidiPacket[] arr = new MidiPacket[1];
 		public void Send (byte[] mevent, int offset, int length, long timestamp)
 		{
-			unsafe {
-				fixed (byte* ptr = mevent) {
-					arr [0] = new MidiPacket(timestamp, (ushort)length, (IntPtr)(ptr + offset));
-					port.Send (details.Endpoint, arr);
-				}
-			}
+			arr [0] = new MidiPacket(timestamp, mevent, offset, length);
+			port.Send (details.Endpoint, arr);
 		}
 	}
 }


### PR DESCRIPTION
Use simpler constructor for MidiPacket on CoreMidi, as Xamarin CoreMidi as an issue with pointer-initialized MidiPackets.	
https://github.com/atsushieno/managed-midi/issues/76