### PR TITLE
Resolved null exception for WinMM

### DIFF
--- a/Commons.Music.Midi.DesktopShared/winmm/WinmmMidiAccess.cs
+++ b/Commons.Music.Midi.DesktopShared/winmm/WinmmMidiAccess.cs
@@ -381,9 +381,16 @@ namespace Commons.Music.Midi.WinMM
                     {
                         // allocate unmanaged memory and hand ownership over to the device driver
 
-                        header.Data = Marshal.AllocHGlobal(evt.ExtraDataLength);
-                        header.BufferLength = evt.ExtraDataLength;
-                        Marshal.Copy(evt.ExtraData, evt.ExtraDataOffset, header.Data, header.BufferLength);
+                        if (evt.ExtraDataLength > 0)
+                        {
+							header.Data = Marshal.AllocHGlobal(evt.ExtraDataLength);
+	                        header.BufferLength = evt.ExtraDataLength;
+	                        Marshal.Copy(evt.ExtraData, evt.ExtraDataOffset, header.Data, header.BufferLength);
+                        }
+                        else
+                        {
+	                        header.Data = IntPtr.Zero;
+                        }
 
                         ptr = Marshal.AllocHGlobal(hdrSize);
                         Marshal.StructureToPtr(header, ptr, false);


### PR DESCRIPTION
Here is an example for my [Launchpad Pro](https://fael-downloads-prod.focusrite.com/customer/prod/s3fs-public/downloads/Launchpad%20Pro%20Programmers%20Reference%20Guide%201.01.pdf) where I'm experiencing this issue

```cs
// 0xF0 SysEx
// 0x00 0x20 0x29 manufacturer ID (Novation )
// 0x02 0x10 Product ID (Launchpad Pro)
Output.Send([0xF0, 0x00, 0x20, 0x29, 0x02, 0x10, 0x2D, 0x1], 0, 9, 0); // Mode selection: Standalone mode
Output.Send([0xF0, 0x00, 0x20, 0x29, 0x02, 0x10, 0x2C, 0x3], 0, 9, 0); // Standalone Layout select: Programmer
Output.Send([0xF0, 0x00, 0x20, 0x29, 0x02, 0x10, 0x0A, 11, 04], 0, 10, 0); // Set LEDs (standard color mode): LED 1, 1 to white
```

Mode selection gives null exception on [Commons.Music.Midi.DesktopShared/winmm/WinmmMidiAccess.cs](https://github.com/atsushieno/managed-midi/pull/81/files#diff-611e4b02621220d9c9a85198a56615987a7382f0c139cac4274205d1b546baff) row 386 `Marshal.Copy(evt.ExtraData, evt.ExtraDataOffset, header.Data, header.BufferLength);` fails because `evt.ExtraData` is null and `evt.ExtraDataLength` is 0.
Platform Windows 11 64 net8.0

![image](https://github.com/user-attachments/assets/4bf4d9bb-f958-405b-95d6-6c8805922644)
