### PR TITLE
Fix Linux hardware input device support by implementing running status for MidiEvent.Convert 

### DIFF
--- a/Commons.Music.Midi.Shared/SMF.cs
+++ b/Commons.Music.Midi.Shared/SMF.cs
@@ -335,7 +335,7 @@ namespace Commons.Music.Midi
 					}
 				} else {
 					var z = MidiEvent.FixedDataSize(runningStatus);
-					if (end < i + z)
+					if (end < i + z - 1)
 						throw new Exception($"Received data was incomplete to build MIDI running status message for '{runningStatus:X}' status.");
 					yield return new MidiEvent(runningStatus,
 						bytes[i], 


### PR DESCRIPTION
This fixes hardware input devices on Linux because Alsa sends running status messages.

Tested in my .netstandard2.0 fork on Linux (EndeavourOS) and Windows.

(At this time I haven't checked if this matches the MIDI spec completely, however it's working with three different devices)

Fixes #71 