### PR TITLE
Fix MidiEvent.EventType

### DIFF
--- a/Commons.Music.Midi.Shared/SMF.cs
+++ b/Commons.Music.Midi.Shared/SMF.cs
@@ -394,7 +394,7 @@ namespace Commons.Music.Midi
 		public byte EventType {
 			get {
 				var statusByte = StatusByte;
-				if (FixedDataSize(statusByte) == 0)
+				if (statusByte >= 0xF0)
 					return statusByte;
 				return (byte)(statusByte & 0xF0);
 			}


### PR DESCRIPTION
Currently there is a problem with this property: if you have a MidiClock (0xF8) message, the property returns SysEx1 (0xF0)

MidiClock (0xF8): `1111 1000`
EventType property returns SysEx1 (0xF0) `1111 0000` (discarded lower 4 bits)

The change made in this PR simply returns the unmodified status byte if it's above or equal to 0xF0, because messages in this range don't encode the channel into the status byte