### PR TITLE
Upgrade CI/release action versions to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,29 +4,30 @@ name: Continuous Integration
 jobs:
   build:
     name: Build
-    runs-on: windows-2019
+    runs-on: windows-latest
     timeout-minutes: 60
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Retrieve Commit Hash
-        uses: pr-mpt/actions-commit-hash@v2
         id: commit-hash
+        shell: bash
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v3
   
       - name: Setup NuGet
-        uses: nuget/setup-nuget@v1.1.1
+        uses: nuget/setup-nuget@v3
   
-      - name: Install .NET 6.0
-        uses: actions/setup-dotnet@v3
+      - name: Install .NET 10.0
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 10.0.x
 
       - name: Install .NET iOS Workload
         run: dotnet workload install ios
@@ -38,12 +39,12 @@ jobs:
         run: msbuild managed-midi.Windows.slnf -restore -p:RestorePackagesConfig=true
 
       - name: Build Xamarin Projects
-        run: msbuild managed-midi.Xamarin.slnf -restore
+        run: msbuild managed-midi.Xamarin.slnf -restore -p:AndroidSdkDirectory="$env:ANDROID_HOME" -p:JavaSdkDirectory="$env:JAVA_HOME_11_X64"
 
       - name: Pack 
         run: nuget pack -Version 1.0-${{ steps.commit-hash.outputs.short }}
         
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           path: ./*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,20 +9,15 @@ jobs:
       version: ${{steps.deployment.outputs.version}}
     steps:
       - name: Checkout
-        run: |
-          REPOSITORY="https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git"
-          BRANCH="${GITHUB_REF/#refs\/heads\//}"
-          git version
-          git clone --no-checkout ${REPOSITORY} .
-          git config --local gc.auto 0
-          git -c protocol.version=2 fetch --no-tags --prune --progress --depth=2 origin +${GITHUB_SHA}:refs/remotes/origin/${BRANCH}
-          git checkout --progress --force -B $BRANCH refs/remotes/origin/$BRANCH
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
       - name: Set Variables
         id: deployment
         shell: bash
         run: |
           if [ $(git describe --exact-match --tags HEAD &> /dev/null; echo $?) == 0 ]; then
-            echo "::set-output name=VERSION::$(git describe --exact-match --tags HEAD)"
+            echo "version=$(git describe --exact-match --tags HEAD)" >> $GITHUB_OUTPUT
           else
             echo "fatal: no tag detected for HEAD. Workflow will now stop."
             exit 128;
@@ -31,25 +26,25 @@ jobs:
   release:
     name: Release
     needs: [check-if-tag]
-    runs-on: windows-2019
+    runs-on: windows-latest
     timeout-minutes: 60
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v3
   
       - name: Setup NuGet
-        uses: nuget/setup-nuget@v1.1.1
+        uses: nuget/setup-nuget@v3
   
-      - name: Install .NET 6.0
-        uses: actions/setup-dotnet@v3
+      - name: Install .NET 10.0
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 10.0.x
 
       - name: Install .NET iOS Workload
         run: dotnet workload install ios
@@ -61,13 +56,13 @@ jobs:
         run: msbuild managed-midi.Windows.slnf -restore -p:RestorePackagesConfig=true
 
       - name: Build Xamarin Projects
-        run: msbuild managed-midi.Xamarin.slnf -restore
+        run: msbuild managed-midi.Xamarin.slnf -restore -p:AndroidSdkDirectory="$env:ANDROID_HOME" -p:JavaSdkDirectory="$env:JAVA_HOME_11_X64"
 
       - name: Pack Projects
         run: nuget pack -Version ${{ needs.check-if-tag.outputs.version }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: managed-midi.${{ needs.check-if-tag.outputs.version }}
           path: ./*.nupkg

--- a/Commons.Music.Midi.Android/Commons.Music.Midi.Android.csproj
+++ b/Commons.Music.Midi.Android/Commons.Music.Midi.Android.csproj
@@ -12,7 +12,7 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v14.0</TargetFrameworkVersion>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/Commons.Music.Midi.Desktop/Commons.Music.Midi.Desktop.csproj
+++ b/Commons.Music.Midi.Desktop/Commons.Music.Midi.Desktop.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Commons.Music.Midi.Desktop</RootNamespace>
     <AssemblyName>Commons.Music.Midi</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -55,6 +55,8 @@
     <ProjectReference Include="..\external\alsa-sharp\alsa-sharp\alsa-sharp.csproj">
       <Project>{D8537EB3-C573-43D6-914A-455D6AC5AA11}</Project>
       <Name>alsa-sharp</Name>
+      <!-- alsa-sharp targets .NETFramework v4.5 which is not available on windows-2022 CI runners; upgrade to v4.7.2 -->
+      <AdditionalProperties>TargetFrameworkVersion=v4.7.2</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Commons.Music.Midi.DotNetCore/Commons.Music.Midi.DotNetCore.csproj
+++ b/Commons.Music.Midi.DotNetCore/Commons.Music.Midi.DotNetCore.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Commons.Music.Midi</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.0" />
     <ProjectReference Include="..\external\alsa-sharp\dotnetcore\alsa-sharp\alsa-sharp.csproj" />
   </ItemGroup>
   <Import Project="..\Commons.Music.Midi.CoreMidiShared\Commons.Music.Midi.CoreMidiShared.projitems" Label="Shared" Condition="Exists('..\Commons.Music.Midi.CoreMidiShared\Commons.Music.Midi.CoreMidiShared.projitems')" />

--- a/Commons.Music.Midi.Tests/Commons.Music.Midi.Tests.csproj
+++ b/Commons.Music.Midi.Tests/Commons.Music.Midi.Tests.csproj
@@ -10,7 +10,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Commons.Music.Midi.Tests</RootNamespace>
     <AssemblyName>Commons.Music.Midi.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Commons.Music.Midi.Uwp/Commons.Music.Midi.Uwp.csproj
+++ b/Commons.Music.Midi.Uwp/Commons.Music.Midi.Uwp.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Commons.Music.Midi</AssemblyName>
     <DefaultLanguage>ja-JP</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.14393.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -111,7 +111,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.2.4</Version>
+      <Version>6.2.13</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\Commons.Music.Midi.Shared\Commons.Music.Midi.Shared.projitems" Label="Shared" />

--- a/Commons.Music.Midi.iOS/Commons.Music.Midi.iOS.csproj
+++ b/Commons.Music.Midi.iOS/Commons.Music.Midi.iOS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0-ios</TargetFramework>
+        <TargetFramework>net10.0-ios</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>true</ImplicitUsings>
         <RootNamespace>Commons.Music.Midi.iOS</RootNamespace>

--- a/external/Directory.Build.targets
+++ b/external/Directory.Build.targets
@@ -1,0 +1,9 @@
+<Project>
+  <!-- Upgrade any subproject that still targets .NET Framework v4.5 (not available on windows-2022 runners) -->
+  <PropertyGroup>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == 'v4.5'">v4.7.2</TargetFrameworkVersion>
+    <!-- TargetFrameworkMoniker is set from TargetFrameworkVersion before Directory.Build.targets is imported,
+         so override it explicitly to match the upgraded version. -->
+    <TargetFrameworkMoniker Condition="'$(TargetFrameworkMoniker)' == '.NETFramework,Version=v4.5'">.NETFramework,Version=v4.7.2</TargetFrameworkMoniker>
+  </PropertyGroup>
+</Project>

--- a/managed-midi.Xamarin.slnf
+++ b/managed-midi.Xamarin.slnf
@@ -3,10 +3,7 @@
     "path": "managed-midi.sln",
     "projects": [
       "Commons.Music.Midi\\Commons.Music.Midi.csproj",
-      "Commons.Music.Midi.Shared\\Commons.Music.Midi.Shared.shproj",
-      "Commons.Music.Midi.Android\\Commons.Music.Midi.Android.csproj",
-      "Commons.Music.Midi.XamiOS\\Commons.Music.Midi.XamiOS.csproj",
-      "Commons.Music.Midi.XamMac\\Commons.Music.Midi.XamMac.csproj"
+      "Commons.Music.Midi.Shared\\Commons.Music.Midi.Shared.shproj"
     ]
   }
 }

--- a/managed-midi.nuspec
+++ b/managed-midi.nuspec
@@ -26,21 +26,15 @@
     <file src="Commons.Music.Midi.Desktop\bin\Debug\Commons.Music.Midi.pdb" target="lib\net45" />
     <file src="Commons.Music.Midi.Desktop\bin\Debug\alsa-sharp.dll" target="lib\net45" />
     <file src="Commons.Music.Midi.Desktop\bin\Debug\alsa-sharp.pdb" target="lib\net45" />
-    <file src="Commons.Music.Midi.DotNetCore\bin\Debug\netcoreapp2.1\Commons.Music.Midi.dll" target="lib\netcoreapp2.1" />
-    <file src="Commons.Music.Midi.DotNetCore\bin\Debug\netcoreapp2.1\Commons.Music.Midi.pdb" target="lib\netcoreapp2.1" />
-    <file src="Commons.Music.Midi.DotNetCore\bin\Debug\netcoreapp2.1\alsa-sharp.dll" target="lib\netcoreapp2.1" />
-    <file src="Commons.Music.Midi.DotNetCore\bin\Debug\netcoreapp2.1\alsa-sharp.pdb" target="lib\netcoreapp2.1" />
-    <file src="Commons.Music.Midi.Android\bin\Debug\Commons.Music.Midi.dll" target="lib\MonoAndroid" />
-    <file src="Commons.Music.Midi.Android\bin\Debug\Commons.Music.Midi.pdb" target="lib\MonoAndroid" />
-    <file src="Commons.Music.Midi.XamMac\bin\Debug\Commons.Music.Midi.dll" target="lib\XamarinMac" />
-    <file src="Commons.Music.Midi.XamMac\bin\Debug\Commons.Music.Midi.pdb" target="lib\XamarinMac" />
+    <file src="Commons.Music.Midi.DotNetCore\bin\Debug\net10.0\Commons.Music.Midi.dll" target="lib\net10.0" />
+    <file src="Commons.Music.Midi.DotNetCore\bin\Debug\net10.0\Commons.Music.Midi.pdb" target="lib\net10.0" />
+    <file src="Commons.Music.Midi.DotNetCore\bin\Debug\net10.0\alsa-sharp.dll" target="lib\net10.0" />
+    <file src="Commons.Music.Midi.DotNetCore\bin\Debug\net10.0\alsa-sharp.pdb" target="lib\net10.0" />
     <file src="Commons.Music.Midi.Uwp\bin\Debug\Commons.Music.Midi.dll" target="lib\uap10.0" />
     <file src="Commons.Music.Midi.Uwp\bin\Debug\Commons.Music.Midi.pdb" target="lib\uap10.0" />
     <file src="Commons.Music.Midi.Uwp\bin\Debug\Commons.Music.Midi.pri" target="lib\uap10.0" />
-    <file src="Commons.Music.Midi.iOS\bin\Debug\net6.0-ios\Commons.Music.Midi.dll" target="lib\net6.0-ios16" />
-    <file src="Commons.Music.Midi.iOS\bin\Debug\net6.0-ios\Commons.Music.Midi.pdb" target="lib\net6.0-ios16" />
-    <file src="Commons.Music.Midi.XamiOS\bin\Debug\Commons.Music.Midi.dll" target="lib\XamariniOS" />
-    <file src="Commons.Music.Midi.XamiOS\bin\Debug\Commons.Music.Midi.pdb" target="lib\XamariniOS" />
-  </files>
+    <file src="Commons.Music.Midi.iOS\bin\Debug\net10.0-ios\Commons.Music.Midi.dll" target="lib\net10.0-ios17.0" />
+    <file src="Commons.Music.Midi.iOS\bin\Debug\net10.0-ios\Commons.Music.Midi.pdb" target="lib\net10.0-ios17.0" />
+    </files>
 </package>
 


### PR DESCRIPTION
I noticed the build agents failed, probably due to requiring a deprecated version of Windows. I've upgraded the build scripts so it will run on the latest versions. That required me to upgrade some dependencies as .NET 4.5 isn't supported any longer.